### PR TITLE
Fix work on MODX 3

### DIFF
--- a/core/components/phpthumbon/model/phpthumbon/phpthumbon.class.php
+++ b/core/components/phpthumbon/model/phpthumbon/phpthumbon.class.php
@@ -153,8 +153,10 @@ class phpThumbOn
         $out = false;
         $new = true;
         if (!$this->modx->loadClass('modphpthumb', $this->modx->getOption('core_path') . 'model/phpthumb/', true, true)) {
-            $this->modx->log(modX::LOG_LEVEL_ERROR, '[phpthumbon] Could not load phpthumb class');
-            $this->_flag = false;
+            if (!$this->modx->loadClass('modphpthumb', $this->modx->getOption('core_path') . 'model/modx/', true, true)) {
+                $this->modx->log(modX::LOG_LEVEL_ERROR, '[phpthumbon] Could not load phpthumb class');
+                $this->_flag = false;
+            }
         }
         if ($this->_flag) {
             $this->_phpThumb = new modPhpThumb($this->modx, $this->getConfig());


### PR DESCRIPTION
В MODX 3 провели рефакторинг и теперь класс `modphpthumb` будет находиться в папке `core/model/modx/`